### PR TITLE
Added changes for Model1 uppercase-only machines.

### DIFF
--- a/src/trs/trs-lib/screen.c
+++ b/src/trs/trs-lib/screen.c
@@ -13,6 +13,11 @@ void init_hardware()
   static uint8_t background_buffer[SCREEN_WIDTH * SCREEN_HEIGHT];
   set_screen(SCREEN_BASE, background_buffer,
 	     SCREEN_WIDTH, SCREEN_HEIGHT);
+
+  // Determine if the screen has lowercase by writing/reading screen memory.
+  // An unmodified M1 will read back 32 instead of 96.
+  *(volatile uint8_t *)SCREEN_BASE = 96;
+  screen.is_uc = *(volatile uint8_t *)SCREEN_BASE != 96;
 }
 #endif
 

--- a/src/trs/trs-lib/screen.h
+++ b/src/trs/trs-lib/screen.h
@@ -13,6 +13,7 @@ typedef void (*screen_update_range_t)(uint8_t*, uint8_t*);
 typedef struct {
   uint8_t  width;
   uint8_t  height;
+  uint8_t is_uc;
   uint8_t* screen_base;
   uint8_t* background;
   uint8_t* current;
@@ -20,6 +21,9 @@ typedef struct {
 } SCREEN;
 
 extern SCREEN screen;
+
+// Convert character to uppercase if screen is uppercase-only to avoid gibberish.
+#define SCREEN_TO_UC(UC, C)  (((UC) && ((C) >= 96 && (C) < 128)) ? ((C)-32) : (C))
 
 void init_hardware();
 void set_screen(uint8_t* screen_base,

--- a/src/trs/trs-lib/window.c
+++ b/src/trs/trs-lib/window.c
@@ -92,7 +92,8 @@ void wnd_print(window_t* wnd, bool single_line, const char* str) {
     from = p = get_screen_pos(wnd);
   
     while (str != next) {
-      *p++ = *str++;
+      *p++ = SCREEN_TO_UC(screen.is_uc, *str);
+      str++;
       wnd->cx++;
     }
     screen_update_range(from, p);
@@ -212,7 +213,7 @@ void wnd_popup(const char* msg) {
     if (x == 0 || x == len - 1) {
       *p1 = 191;
     } else {
-      *p1 = msg[x - 1];
+      *p1 = SCREEN_TO_UC(screen.is_uc, msg[x - 1]);
     }
     p1++;
   }


### PR DESCRIPTION
The windowing library performs writes directly to screen memory which does not work as you might expect for uppercase-only Model1's.  The proposed change detects uppercase-only hardware and performs the necessary translations.